### PR TITLE
Enable compilation if --strict compiler option is enabled.

### DIFF
--- a/src/models/card/cardRanks.model.ts
+++ b/src/models/card/cardRanks.model.ts
@@ -3,7 +3,7 @@ import { ICard } from './card.interface'
 import { IRankSet } from './rankSet.interface'
 
 export class RankSet implements IRankSet {
-  public rankSet: CardName[]
+  public rankSet: CardName[] = []
   public cardHigherThan (thisCard: ICard, compareCard: ICard): boolean {
     return this.getRankValue(thisCard) > this.getRankValue(compareCard)
   }

--- a/src/models/cardCollection/cardCollection.model.ts
+++ b/src/models/cardCollection/cardCollection.model.ts
@@ -19,7 +19,7 @@ export class CardCollection implements ICardCollection {
    * means something: "Hand", "Discard Pile",
    * "In Play", etc.
    */
-  public name: string
+  public name: string = ''
   private shuffleService: IShuffleService = new DurstenfeldShuffleService()
   private objectComparer: IObjectComparer = new StringifyComparer()
 

--- a/src/models/poker/pokerHandResult.model.ts
+++ b/src/models/poker/pokerHandResult.model.ts
@@ -9,7 +9,7 @@ export class PokerHandResult {
    * Type of hand created with
    * `cardsUsed`.
    */
-  public handType: PokerHandType
+  public handType: PokerHandType | undefined
   /**
    * Comparable value of current hand
    * to rank above or below another
@@ -67,6 +67,10 @@ export class PokerHandResult {
   }
 
   toString (): string {
+    if(this.handType === undefined) {
+      return '';
+    }
+
     return PokerHandType[this.handType]
       // Look for long acronyms and filter out the last letter
       .replace(/([A-Z]+)([A-Z][a-z])/g, ' $1 $2')

--- a/src/models/poker/pokerHandResult.spec.ts
+++ b/src/models/poker/pokerHandResult.spec.ts
@@ -3,6 +3,7 @@ import { Suit, PlayingCard, CardName, PokerHandResult, PokerHandType, AceLowRank
 
 test('test tostring of hand types', async t => {
   const handResult = new PokerHandResult()
+  t.deepEqual(handResult.toString(), '')
   handResult.setHandType(PokerHandType.HighCard)
   t.deepEqual(handResult.toString(), 'High Card')
   handResult.setHandType(PokerHandType.OnePair)


### PR DESCRIPTION
## What kind of change does this PR introduce?
- [x] bug fix
- [ ] feature
- [ ] docs update
- [ ] other

## What is the current behavior?
Compilation fails if the --strict option is enabled.
Specifically, this corrects issues with the --strictPropertyInitialization option.

## What is the new behavior?
Compilation now succeeds with this option enabled or disabled