### PR TITLE
Fix empty result when calling PokerScoreService.scoreCards with community

### DIFF
--- a/src/services/pokerScore.service.ts
+++ b/src/services/pokerScore.service.ts
@@ -29,7 +29,7 @@ export class PokerScoreService implements IPokerScoreService {
       throw new PokerScoringError('Invalid cards provided. Please send at least 5 cards.');
     }
     // find best hand
-    for (const combination of IterableExtensions.Combinations(cards, 5)) {
+    for (const combination of IterableExtensions.Combinations(playerCards, 5)) {
       const result = this.calculate(combination);
       if (result.value > bestHand.value) {
         bestHand = result;


### PR DESCRIPTION
Never too late!

## What kind of change does this PR introduce?
- [X] bug fix
- [ ] feature
- [ ] docs update
- [ ] other

## What is the current behavior?
Calling scoreCards with cards and community always results in a result of value 0.



## What is the new behavior (if this is a feature change)?
Calling scoreCards returns as expected


## Other information

